### PR TITLE
Minor changes to end-to-end testing

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -3,12 +3,15 @@
 
 name: End to End tests
 
-# We only run this manually
 on:
-  workflow_dispatch:
-  push:
+  pull_request:
     branches:
-      - feature/initial_e2e_testing
+      - "develop"
+    paths-ignore:
+      - '**/*md'
+      - '**/*tex'
+  workflow_dispatch:
+
 
 jobs:
   build:

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -39,7 +39,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
                  'pdoc',
                  'pytest',
                  'pytest-cov',
+                 "pytest-flakefinder",
                  "icecream"
                  ],
     },

--- a/tests/test_end_to_end_pandemia.py
+++ b/tests/test_end_to_end_pandemia.py
@@ -185,7 +185,6 @@ def test_e2e_health_and_movement_model(
     run_end_to_end_simulation(input_scenario, get_default_expected_df)
 
 
-# @pytest.mark.skip("Not implemented yet")
 @pytest.mark.slow
 def test_e2e_hospitalization_and_death_model(
     get_default_expected_df, run_end_to_end_simulation


### PR DESCRIPTION
Small PR with minor fixes to end-to-end testing
* Add [pytest-flakefinder](https://github.com/dropbox/pytest-flakefinder) to the test dependencies.
* Change rules on GitHub Actions to run end-to-end tests on PRs