### PR TITLE
Add flake tests to GH Actions

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -4,6 +4,9 @@
 name: End to End tests
 
 on:
+  push:
+    branches:
+      - "develop"
   pull_request:
     branches:
       - "develop"

--- a/.github/workflows/flake-tests.yml
+++ b/.github/workflows/flake-tests.yml
@@ -1,0 +1,68 @@
+# These tests related to this issue:
+# https://github.com/PandemiaProject/pandemia/issues/66
+#
+# This workflow runs certain test repeatedly to ensure that they produce consistent results
+# Once these tests repeated run without failing, this workflow file cna be removed and issue #66 closed.
+
+name: Flake tests
+
+on:
+  schedule:
+    # At 04:17 every morning
+    # https://crontab.guru/#17_4_*_*_*
+    - cron: '17 4 * * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.allow-fail }}
+
+    strategy:
+      # We use `fail-fast: false` for teaching purposes. This ensure that all combinations of the matrix
+      # will run even if one or more fail. 
+      fail-fast: false
+      matrix:
+        python-version: ["3.10"]
+        os: [ubuntu-22.04, windows-latest]
+        # os: [ubuntu-22.04]
+        test-group: [slow]
+        allow-fail: [false]
+
+        # This is the syntax for running tests in MacOS as well as Windows + Linux. However it is excluded
+        # for now due to the high cost of MacOS usage:
+        # os: [ubuntu-latest, windows-latest, macos-12]
+
+        # This is the syntax for adding an one-off variation to the matrix configuration above
+        # include:
+        #   - python-version: "3.10"
+        #     os: ubuntu-22.04
+        #     test-group: known_failing
+        #     allow-fail: true
+
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    
+    # Install Pandemia itself from then source
+    - name: Install Pandemia
+      run: |
+        python -m pip install -e .
+    # Install any packages require for testing
+    - name: Install tests for Pandemia
+      run: |
+        python -m pip install -e .[test]
+    - name: Compile the C code
+      run: |
+        make
+    # Now run the tests
+    - name: Test with pytest with the "slow" marker (other tests will be excluded)
+      run: |
+        pytest -m slow -k test_end_to_end_all_components --flake-finder --flake-runs=20
+        pytest -m slow -k test_end_to_end_global --flake-finder --flake-runs=20
+
+


### PR DESCRIPTION
The PR adds a nightly check on the status of https://github.com/PandemiaProject/pandemia/issues/66

The two tests mentioned in #66 are run 20 times each on a windows and a linux VM. 

Once these tests repeatedly run without failing, the workflow file `.github/workflows/flake-tests.yml` can be removed and issue #66 closed.
