### PR TITLE
Enable MacOS on CI builds

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -29,9 +29,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10"]
-        # os: [ubuntu-22.04, windows-latest]
-        # This is the syntax for running tests in MacOS as well as Windows + Linux. However it is excluded
-        # for now due to the high cost of MacOS usage:
+        # Tests are run on MacOS, Windows and Linux.
+        # There does not appear to be any additional cost for running on Mac:
         os: [ubuntu-22.04, windows-latest, macos-12]
 
         # os: [ubuntu-22.04]

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -29,14 +29,14 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10"]
-        os: [ubuntu-22.04, windows-latest]
+        # os: [ubuntu-22.04, windows-latest]
+        # This is the syntax for running tests in MacOS as well as Windows + Linux. However it is excluded
+        # for now due to the high cost of MacOS usage:
+        os: [ubuntu-22.04, windows-latest, macos-12]
+
         # os: [ubuntu-22.04]
         test-group: [slow]
         allow-fail: [false]
-
-        # This is the syntax for running tests in MacOS as well as Windows + Linux. However it is excluded
-        # for now due to the high cost of MacOS usage:
-        # os: [ubuntu-latest, windows-latest, macos-12]
 
         # This is the syntax for adding an one-off variation to the matrix configuration above
         # include:

--- a/.github/workflows/flake-tests.yml
+++ b/.github/workflows/flake-tests.yml
@@ -24,14 +24,14 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10"]
-        os: [ubuntu-22.04, windows-latest]
-        # os: [ubuntu-22.04]
+        # os: [ubuntu-22.04, windows-latest]
+        # This is the syntax for running tests in MacOS as well as Windows + Linux. However it is excluded
+        # for now due to the high cost of MacOS usage:
+        os: [ubuntu-22.04, windows-latest, macos-12]        # os: [ubuntu-22.04]
         test-group: [slow]
         allow-fail: [false]
 
-        # This is the syntax for running tests in MacOS as well as Windows + Linux. However it is excluded
-        # for now due to the high cost of MacOS usage:
-        # os: [ubuntu-latest, windows-latest, macos-12]
+
 
         # This is the syntax for adding an one-off variation to the matrix configuration above
         # include:

--- a/.github/workflows/flake-tests.yml
+++ b/.github/workflows/flake-tests.yml
@@ -24,14 +24,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10"]
-        # os: [ubuntu-22.04, windows-latest]
-        # This is the syntax for running tests in MacOS as well as Windows + Linux. However it is excluded
-        # for now due to the high cost of MacOS usage:
-        os: [ubuntu-22.04, windows-latest, macos-12]        # os: [ubuntu-22.04]
+        # Tests are run on MacOS, Windows and Linux.
+        # There does not appear to be any additional cost for running on Mac:
+        os: [ubuntu-22.04, windows-latest, macos-12]
         test-group: [slow]
         allow-fail: [false]
-
-
 
         # This is the syntax for adding an one-off variation to the matrix configuration above
         # include:


### PR DESCRIPTION
@AoifeHughes and I have come across a problem that **_might_** be MacOS-specific. The same problem did not occur with the [same code on GitHub Actions on Linux or Windows](https://github.com/PandemiaProject/pandemia/actions/workflows/end-to-end-tests.yml?query=branch%3Adevelop).

# How to reproduce

On MacOS:
1. Take a clean clone of the repo
2. `make clean`
3. `make`
4. `pytest -m slow -k test_e2e_testing_and_contact_tracing_model`

# Expected result

The test should pass.

# Actual result

```
platform darwin -- Python 3.10.0, pytest-7.1.2, pluggy-1.0.0
rootdir: /Users/a.smith/code/pandemia/temp_clone/pandemia, configfile: pytest.ini
plugins: flakefinder-1.1.0, typeguard-2.13.3, cov-4.0.0
collected 12 items / 11 deselected / 1 selected                                                                                                                                              

tests/test_end_to_end_pandemia.py F                                                                                                                                                    [100%]/Users/a.smith/.pyenv/versions/3.10.0/lib/python3.10/site-packages/coverage/control.py:801: CoverageWarning: No data was collected. (no-data-collected)
  self._warn("No data was collected.", slug="no-data-collected")


========================================================================================== FAILURES ==========================================================================================
____________________________________________________________________ test_e2e_testing_and_contact_tracing_model[0.5-100] _____________________________________________________________________

get_default_expected_df =     day     iso8601  Test Region 0, Strain: 0  Test Region 0, Strain: 1  ...  Test Region 2, Strain: 0  Test Region 2,...              186                        14                       194                        18

[25 rows x 10 columns]
run_end_to_end_simulation = <function run_end_to_end_simulation.<locals>._run_end_to_end_simulation at 0x125819630>, rel_tol = 0.5, abs_tol = 100

    @pytest.mark.slow
    @pytest.mark.approx_matching
    @pytest.mark.parametrize("rel_tol, abs_tol", [(0.5, 100)])
    def test_e2e_testing_and_contact_tracing_model(
        get_default_expected_df, run_end_to_end_simulation, rel_tol, abs_tol
    ):
        input_scenario = "Scenarios/Test/test_e2e_health_and_movement_model.yaml"
    
        delta_config = {
            "testing_and_contact_tracing_model": {
                "__type__": "default_testing_and_contact_tracing_model.DefaultTestingAndContactTracingModel",
                "quarantine_period_days": 14,
                "symptomatic_disease_threshold": 0.2,
                "prob_quarantine_with_symptoms_without_test": 0.001,
                "prob_quarantine_with_contact_without_test": 0.001,
                "test_threshold": 0.005,
                "test_false_negative": 0.01,
                "max_regular_contacts_to_test": 10,
            }
        }
    
        scenario = _update_config(input_scenario, delta_config)
    
        delta_config = {
            "policy_maker_model": {"__type__": "random_policy_maker_model.RandomPolicyMakerModel", "seed": 1}
        }
    
        scenario = _update_config(scenario, delta_config)
    
>       run_end_to_end_simulation(scenario, get_default_expected_df, rel_tol, abs_tol)

tests/test_end_to_end_pandemia.py:264: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/test_end_to_end_pandemia.py:97: in _run_end_to_end_simulation
    dataframe_approx_match(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

expected_df =     day     iso8601  Test Region 0, Strain: 0  Test Region 0, Strain: 1  ...  Test Region 2, Strain: 0  Test Region 2,...              186                        14                       194                        18

[25 rows x 10 columns]
actual_df =     day     iso8601  Test Region 0, Strain: 0  Test Region 0, Strain: 1  ...  Test Region 2, Strain: 0  Test Region 2,...             1216                        62                      1158                       108

[25 rows x 10 columns]
ignore_cols = [], rel_tol = 0.5, abs_tol = 100

    def dataframe_approx_match(expected_df, actual_df, ignore_cols, rel_tol, abs_tol):
        # We don't require that the two dataframes have the columns in the same order,
        # but we do compare the content of the individual series
    
        # Exclude the ID and datetime stamp columns
        interesting_columns_df = expected_df.iloc[:, 2:]
        ic(interesting_columns_df.columns)
        ic(len(interesting_columns_df))
    
        for col_name, expected_series in interesting_columns_df.items():
            # for expected_ser, actual_ser in zip(expected_df)
            ic(col_name)
            actual_series = actual_df[col_name]
>           assert_allclose(
                actual_series, expected_series, rtol=rel_tol, atol=abs_tol, verbose=True
            )
E           AssertionError: 
E           Not equal to tolerance rtol=0.5, atol=100
E           
E           Mismatched elements: 11 / 25 (44%)
E           Max absolute difference: 4552
E           Max relative difference: 1.06043046
E            x: array([10202, 33990, 38558, 40130, 41226, 42244, 43512, 35386, 15604,
E                  13102, 13400, 13514, 13350, 11854, 10448,  8460,  8206,  8118,
E                   8132,  7722,  7090,  6420,  5774,  5214,  4978])
E            y: array([10202, 34056, 38716, 40450, 41722, 42838, 44302, 36278, 14050,
E                  10302,  9338,  8962,  8814,  8216,  6842,  5756,  5284,  4932,
E                   4546,  4066,  3618,  3156,  2872,  2622,  2416])

tests/test_end_to_end_pandemia.py:128: AssertionError
------------------------------------------------------------------------------------ Captured stdout call ------------------------------------------------------------------------------------
pandemia 0.1.0
[INFO] root: State info:
[INFO] root:   Run ID: 9fb448bcb0b6425fa5d10ee7105f7a1c
[INFO] root:   pandemia version: 0.1.0
[INFO] root:   Created at: 2023-02-03 09:02:22.076897
[INFO] sim_state: New clock created at 2020-02-23 00:00:00, tick_length = 28800, simulation_days = 25
pandemia.world.world_factory
pandemia.world.world_factory.control_world_factory
[INFO] control_world_factory: Creating world...
[INFO] control_world_factory: Creating 4 test regions...
[INFO] control_world_factory: Created world with 200000 agents
pandemia.components.seasonal_effects_model
pandemia.components.seasonal_effects_model.void_seasonal_effects_model
pandemia.components.health_model
pandemia.components.health_model.default_health_model
pandemia.components.movement_model
pandemia.components.movement_model.default_movement_model
pandemia.components.hospitalization_and_death_model
pandemia.components.hospitalization_and_death_model.void_hospitalization_and_death_model
pandemia.components.testing_and_contact_tracing_model
pandemia.components.testing_and_contact_tracing_model.default_testing_and_contact_tracing_model
pandemia.components.vaccination_model
pandemia.components.vaccination_model.void_vaccination_model
pandemia.components.travel_model
pandemia.components.travel_model.void_travel_model
pandemia.components.policy_maker_model
pandemia.components.policy_maker_model.random_policy_maker_model
[INFO] sim_state: Creating reporter 'csv.StrainCounts'...
pandemia.reporters
pandemia.reporters.csv
[INFO] sim: Simulation created at 2023-02-03 09:02:33.664156 with ID=8d008b0e6e93417684791828ac964415
[INFO] sim: Simulating outbreak on 4 CPU(s)...
[INFO] root: Simulation finished successfully in 0.46 seconds.
[INFO] sim: Total deaths: 0
------------------------------------------------------------------------------------ Captured stderr call ------------------------------------------------------------------------------------
ic| fname_altered_scenario: '/private/var/folders/82/rww6fmfj2dx_lcstqhj_0hd80000gr/T/pytest-of-a.smith/pytest-4/test_e2e_testing_and_contact_t0/test_altered_scenario.yaml'
ic| fname_actual_results: '/private/var/folders/82/rww6fmfj2dx_lcstqhj_0hd80000gr/T/pytest-of-a.smith/pytest-4/test_e2e_testing_and_contact_t0/test_e2e_testing_and_contact_tracing_model.csv'
ic| interesting_columns_df.columns: Index(['Test Region 0, Strain: 0', 'Test Region 0, Strain: 1',
                                           'Test Region 1, Strain: 0', 'Test Region 1, Strain: 1',
                                           'Test Region 2, Strain: 0', 'Test Region 2, Strain: 1',
                                           'Test Region 3, Strain: 0', 'Test Region 3, Strain: 1'],
                                          dtype='object')
ic| len(interesting_columns_df): 25
ic| col_name: 'Test Region 0, Strain: 0'
====================================================================================== warnings summary ======================================================================================
../../../../.pyenv/versions/3.10.0/lib/python3.10/site-packages/joblib/backports.py:22
  /Users/a.smith/.pyenv/versions/3.10.0/lib/python3.10/site-packages/joblib/backports.py:22: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
    import distutils  # noqa

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

---------- coverage: platform darwin, python 3.10.0-final-0 ----------
Coverage HTML written to dir htmlcov

================================================================================== short test summary info ===================================================================================
FAILED tests/test_end_to_end_pandemia.py::test_e2e_testing_and_contact_tracing_model[0.5-100] - AssertionError: 
======================================================================== 1 failed, 11 deselected, 1 warning in 17.21s ========================================================================
```
